### PR TITLE
getThing: check casterPtr is non-null

### DIFF
--- a/core/Kernel.cc
+++ b/core/Kernel.cc
@@ -162,8 +162,8 @@ Thing* Pipeline::getThing(PtrVec<BaseThing>& vec, Pred<Thing> pred)
 {
   for (const auto& pThing : vec) {
     auto &thing = *pThing;          // https://stackoverflow.com/q/46494928
-    if (typeid(thing) == typeid(Thing)) {
-      auto castedPtr = dynamic_cast<Thing*>(pThing.get());
+    auto castedPtr = dynamic_cast<Thing*>(pThing.get());
+    if (castedPtr) {
       if (!pred.has_value() || pred.value()(*castedPtr))
         return castedPtr;
     }


### PR DESCRIPTION
to make sure that it works with polymorphic objects