### PR TITLE
CMake integration for SelectorFramework and adding abillity to read files through XRootD protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,3 +35,4 @@ target_include_directories(SelectorFramework SYSTEM PUBLIC "${ROOT_INCLUDE_DIRS}
 target_link_libraries(SelectorFramework PUBLIC ROOT::Core ROOT::Hist ROOT::Tree)
 
 set_property(TARGET SelectorFramework PROPERTY SELECTOR_HEADERS "${SELECTOR_FRAMEWORK_HEADERS}")
+install_headers(SelectorFramework)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ target_include_directories(SelectorFramework PUBLIC core)
 
 ROOT_GENERATE_DICTIONARY(Dict_SelectorFramework "${SELECTOR_FRAMEWORK_HEADERS}" 
                          MODULE SelectorFramework OPTIONS -interpreteronly
-                         -inlineInputHeader
                          )
 
 target_include_directories(SelectorFramework SYSTEM PUBLIC "${ROOT_INCLUDE_DIRS}" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 project(SelectorFramework LANGUAGES CXX)
 
 set(SELECTOR_FRAMEWORK_HEADERS
@@ -28,6 +28,11 @@ add_library(SelectorFramework SHARED
 target_include_directories(SelectorFramework PUBLIC core)
 
 ROOT_GENERATE_DICTIONARY(Dict_SelectorFramework "${SELECTOR_FRAMEWORK_HEADERS}" 
-                         MODULE SelectorFramework
+                         MODULE SelectorFramework OPTIONS -interpreteronly
                          )
+
+target_include_directories(SelectorFramework SYSTEM PUBLIC "${ROOT_INCLUDE_DIRS}" )
 target_link_libraries(SelectorFramework PUBLIC ROOT::Core ROOT::Hist ROOT::Tree)
+target_compile_options(SelectorFramework PUBLIC "-Wno-deprecated-volatile")
+
+set_property(TARGET SelectorFramework PROPERTY SELECTOR_HEADERS "${SELECTOR_FRAMEWORK_HEADERS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(SELECTOR_FRAMEWORK_HEADERS
     Util.hh
     )
 
-add_library(SelectorFramework STATIC
+add_library(SelectorFramework SHARED
     core/BaseIO.cc
     core/Clock.cc
     core/ConfigTool.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,5 @@ ROOT_GENERATE_DICTIONARY(Dict_SelectorFramework "${SELECTOR_FRAMEWORK_HEADERS}"
 
 target_include_directories(SelectorFramework SYSTEM PUBLIC "${ROOT_INCLUDE_DIRS}" )
 target_link_libraries(SelectorFramework PUBLIC ROOT::Core ROOT::Hist ROOT::Tree)
-target_compile_options(SelectorFramework PUBLIC "-Wno-deprecated-volatile")
 
 set_property(TARGET SelectorFramework PROPERTY SELECTOR_HEADERS "${SELECTOR_FRAMEWORK_HEADERS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ target_include_directories(SelectorFramework PUBLIC core)
 
 ROOT_GENERATE_DICTIONARY(Dict_SelectorFramework "${SELECTOR_FRAMEWORK_HEADERS}" 
                          MODULE SelectorFramework OPTIONS -interpreteronly
+                         -inlineInputHeader
                          )
 
 target_include_directories(SelectorFramework SYSTEM PUBLIC "${ROOT_INCLUDE_DIRS}" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.12)
+project(SelectorFramework LANGUAGES CXX)
+
+set(SELECTOR_FRAMEWORK_HEADERS
+    Assert.hh
+    BaseIO.hh
+    Clock.hh
+    ConfigTool.hh
+    DirectReader.hh
+    EventBuf.hh
+    Kernel.hh
+    PrefetchLooper.hh
+    RingBuf.hh
+    SimpleAlg.hh
+    SyncReader.hh
+    TimeSyncReader.hh
+    TreeWriter.hh
+    Util.hh
+    )
+
+add_library(SelectorFramework STATIC
+    core/BaseIO.cc
+    core/Clock.cc
+    core/ConfigTool.cc
+    core/Kernel.cc
+    core/Util.cc
+    )
+target_include_directories(SelectorFramework PUBLIC core)
+
+ROOT_GENERATE_DICTIONARY(Dict_SelectorFramework "${SELECTOR_FRAMEWORK_HEADERS}" 
+                         MODULE SelectorFramework
+                         )
+target_link_libraries(SelectorFramework PUBLIC ROOT::Core ROOT::Hist ROOT::Tree)

--- a/core/Kernel.cc
+++ b/core/Kernel.cc
@@ -50,9 +50,10 @@ std::string Pipeline::inFilePath(size_t i)
 TFile* Pipeline::inFile(size_t i)
 {
   const auto& path = inFilePaths.at(i);
-  if (!inFileHandles.count(path))
-    inFileHandles[path] = new TFile(path.c_str());
-  return inFileHandles[path];
+  if (!inFileHandles.count(path)) {
+    inFileHandles[path].reset(TFile::Open(path.c_str()));
+  }
+  return inFileHandles[path].get();
 }
 
 void Pipeline::notifyFileChanged(const Algorithm* reader, size_t i)

--- a/core/Kernel.hh
+++ b/core/Kernel.hh
@@ -122,7 +122,7 @@ private:
   PtrVec<Tool> toolVec;
 
   std::vector<std::string> inFilePaths;
-  std::map<std::string, TFile*> inFileHandles;
+  std::map<std::string, std::unique_ptr<TFile>> inFileHandles;
 };
 
 template <class Thing, class BaseThing, class... Args>


### PR DESCRIPTION
Hi Matt,

I attach the CMakeLists.txt file for SelectorFramework.
It is meant to be included through `add_subdirectory()` function from `IbdSel` CMakeLists.txt, but mostly should also work standalone (function `install_headers` is the only thing leaqing from `IbdSel`).

Also we added support for accessing `TFile`s remotely through `XRootD` since we store data in EOS storage.
It continues to work with the local filesystem files too, it is safe to merge it.